### PR TITLE
Make tests pass with lxml and pycurl installed.

### DIFF
--- a/openid/fetchers.py
+++ b/openid/fetchers.py
@@ -323,11 +323,11 @@ class CurlHTTPFetcher(HTTPFetcher):
 
         # Remove the status line from the beginning of the input
         unused_http_status_line = header_file.readline().lower()
-        if unused_http_status_line.startswith('http/1.1 100 '):
+        if unused_http_status_line.startswith(b'http/1.1 100 '):
             unused_http_status_line = header_file.readline()
             unused_http_status_line = header_file.readline()
 
-        lines = [line.strip() for line in header_file]
+        lines = [line.decode().strip() for line in header_file]
 
         # and the blank line from the end
         empty_line = lines.pop()
@@ -368,7 +368,8 @@ class CurlHTTPFetcher(HTTPFetcher):
         header_list = []
         if headers is not None:
             for header_name, header_value in headers.items():
-                header_list.append('%s: %s' % (header_name, header_value))
+                header = '%s: %s' % (header_name, header_value)
+                header_list.append(header.encode())
 
         c = pycurl.Curl()
         try:
@@ -386,7 +387,7 @@ class CurlHTTPFetcher(HTTPFetcher):
                 if not self._checkURL(url):
                     raise HTTPError("Fetching URL not allowed: %r" % (url,))
 
-                data = io.StringIO()
+                data = io.BytesIO()
 
                 def write_data(chunk):
                     if data.tell() > (1024 * MAX_RESPONSE_KB):
@@ -394,7 +395,7 @@ class CurlHTTPFetcher(HTTPFetcher):
                     else:
                         return data.write(chunk)
 
-                response_header_data = io.StringIO()
+                response_header_data = io.BytesIO()
                 c.setopt(pycurl.WRITEFUNCTION, write_data)
                 c.setopt(pycurl.HEADERFUNCTION, response_header_data.write)
                 c.setopt(pycurl.TIMEOUT, off)
@@ -420,7 +421,7 @@ class CurlHTTPFetcher(HTTPFetcher):
                     resp.headers = response_headers
                     resp.status = code
                     resp.final_url = url
-                    resp.body = data.getvalue()
+                    resp.body = data.getvalue().decode()
                     return resp
 
                 off = stop - int(time.time())

--- a/openid/test/test_etxrd.py
+++ b/openid/test/test_etxrd.py
@@ -32,7 +32,7 @@ def simpleOpenIDTransformer(endpoint):
 
 class TestServiceParser(unittest.TestCase):
     def setUp(self):
-        with open(XRD_FILE) as f:
+        with open(XRD_FILE, 'rb') as f:
             self.xmldoc = f.read()
         self.yadis_url = 'http://unittest.url/'
 
@@ -104,7 +104,7 @@ class TestServiceParser(unittest.TestCase):
     def testNoXRDS(self):
         """Make sure that we get an exception when an XRDS element is
         not present"""
-        with open(NOXRDS_FILE) as f:
+        with open(NOXRDS_FILE, 'rb') as f:
             self.xmldoc = f.read()
         self.assertRaises(
             etxrd.XRDSError,
@@ -121,7 +121,7 @@ class TestServiceParser(unittest.TestCase):
     def testNoXRD(self):
         """Make sure that we get an exception when there is no XRD
         element present."""
-        with open(NOXRD_FILE) as f:
+        with open(NOXRD_FILE, 'rb') as f:
             self.xmldoc = f.read()
         self.assertRaises(
             etxrd.XRDSError,
@@ -137,7 +137,7 @@ class TestCanonicalID(unittest.TestCase):
         filename = datapath(filename)
 
         def test(self):
-            with open(filename) as f:
+            with open(filename, 'rb') as f:
                 xrds = etxrd.parseXRDS(f.read())
             self._getCanonicalID(iname, xrds, expectedID)
         return test

--- a/openid/test/test_openidyadis.py
+++ b/openid/test/test_openidyadis.py
@@ -17,7 +17,8 @@ XRDS_BOILERPLATE = '''\
 '''
 
 def mkXRDS(services):
-    return XRDS_BOILERPLATE % (services,)
+    xrds = XRDS_BOILERPLATE % (services,)
+    return xrds.encode('utf-8')
 
 def mkService(uris=None, type_uris=None, local_id=None, dent='        '):
     chunks = [dent, '<Service>\n']

--- a/openid/test/test_rpverify.py
+++ b/openid/test/test_rpverify.py
@@ -76,7 +76,7 @@ class TestExtractReturnToURLs(unittest.TestCase):
         self.failUnlessDiscoveryFailure('>')
 
     def test_noEntries(self):
-        self.failUnlessXRDSHasReturnURLs('''\
+        self.failUnlessXRDSHasReturnURLs(b'''\
 <?xml version="1.0" encoding="UTF-8"?>
 <xrds:XRDS xmlns:xrds="xri://$xrds"
            xmlns="xri://$xrd*($v*2.0)"
@@ -87,7 +87,7 @@ class TestExtractReturnToURLs(unittest.TestCase):
 ''', [])
 
     def test_noReturnToEntries(self):
-        self.failUnlessXRDSHasReturnURLs('''\
+        self.failUnlessXRDSHasReturnURLs(b'''\
 <?xml version="1.0" encoding="UTF-8"?>
 <xrds:XRDS xmlns:xrds="xri://$xrds"
            xmlns="xri://$xrd*($v*2.0)"
@@ -102,7 +102,7 @@ class TestExtractReturnToURLs(unittest.TestCase):
 ''', [])
 
     def test_oneEntry(self):
-        self.failUnlessXRDSHasReturnURLs('''\
+        self.failUnlessXRDSHasReturnURLs(b'''\
 <?xml version="1.0" encoding="UTF-8"?>
 <xrds:XRDS xmlns:xrds="xri://$xrds"
            xmlns="xri://$xrd*($v*2.0)"
@@ -117,7 +117,7 @@ class TestExtractReturnToURLs(unittest.TestCase):
 ''', ['http://rp.example.com/return'])
 
     def test_twoEntries(self):
-        self.failUnlessXRDSHasReturnURLs('''\
+        self.failUnlessXRDSHasReturnURLs(b'''\
 <?xml version="1.0" encoding="UTF-8"?>
 <xrds:XRDS xmlns:xrds="xri://$xrds"
            xmlns="xri://$xrd*($v*2.0)"
@@ -137,7 +137,7 @@ class TestExtractReturnToURLs(unittest.TestCase):
       'http://other.rp.example.com/return'])
 
     def test_twoEntries_withOther(self):
-        self.failUnlessXRDSHasReturnURLs('''\
+        self.failUnlessXRDSHasReturnURLs(b'''\
 <?xml version="1.0" encoding="UTF-8"?>
 <xrds:XRDS xmlns:xrds="xri://$xrds"
            xmlns="xri://$xrd*($v*2.0)"
@@ -202,7 +202,7 @@ class TestVerifyReturnTo(unittest.TestCase, CatchLogs):
 
     def tearDown(self):
         CatchLogs.tearDown(self)
-    
+
     def test_bogusRealm(self):
         self.assertFalse(trustroot.verifyReturnTo('', 'http://example.com/'))
 


### PR DESCRIPTION
Hi,

I'm in the process of getting this repository packaged and distributed in Debian and Ubuntu. I notice however that if python3-pycurl and python3-lxml are installed the tests for this project fail.

The lxml-related failures are because it doesn't make sense to pass the Xml parser xml in a string with an encoding declared. Doing so results in this error:

`ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.`

There are two ways of solving this: Either remove the encoding, or pass the Xml as a bytestring. I elected to implement the second method.

The pycurl-related errors are also string vs. bytestring related. Options set on the pycurl object have to be set as bytestrings.

I've made all the tests pass, but haven't done any additional testing.

Please do not hesitate to contact me. Until this lands, and a new release is made, I'll carry this diff as a distro-patch in the packaged version.

Cheers!
