### PR TITLE
Cleanup console output when running tests

### DIFF
--- a/admin/runtests
+++ b/admin/runtests
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-import os.path, sys, warnings
+import os.path
+import sys
+import unittest
+
 
 test_modules = [
     'cryptutil',
@@ -74,7 +77,8 @@ def pyunitTests():
         from openid.test import test_examples
     except ImportError as e:
         if 'twill' in str(e):
-            warnings.warn("Could not import twill; skipping test_examples.")
+            raise unittest.SkipTest('Skipping test_examples. '
+                                    'Could not import twill.')
         else:
             raise
     else:
@@ -170,9 +174,8 @@ def django_tests():
     try:
         import django.test.simple
     except ImportError as e:
-        warnings.warn("django.test.simple not found; "
-                      "django examples not tested.")
-        return 0
+        raise unittest.SkipTest("django.test.simple not found; "
+                                "django examples not tested.")
     import djopenid.server.models, djopenid.consumer.models
     print ("Testing Django examples:")
 

--- a/examples/djopenid/server/tests.py
+++ b/examples/djopenid/server/tests.py
@@ -43,22 +43,22 @@ class TestProcessTrustResult(TestCase):
 
         response = views.processTrustResult(self.request)
 
-        self.failUnlessEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         finalURL = response['location']
-        self.failUnless('openid.mode=id_res' in finalURL, finalURL)
-        self.failUnless('openid.identity=' in finalURL, finalURL)
-        self.failUnless('openid.sreg.postcode=12345' in finalURL, finalURL)
+        self.assertIn('openid.mode=id_res', finalURL)
+        self.assertIn('openid.identity=', finalURL)
+        self.assertIn('openid.sreg.postcode=12345', finalURL)
 
     def test_cancel(self):
         self.request.POST['cancel'] = 'Yes'
 
         response = views.processTrustResult(self.request)
 
-        self.failUnlessEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         finalURL = response['location']
-        self.failUnless('openid.mode=cancel' in finalURL, finalURL)
-        self.failIf('openid.identity=' in finalURL, finalURL)
-        self.failIf('openid.sreg.postcode=12345' in finalURL, finalURL)
+        self.assertIn('openid.mode=cancel', finalURL)
+        self.assertNotIn('openid.identity=', finalURL)
+        self.assertNotIn('openid.sreg.postcode=12345', finalURL)
 
 
 class TestShowDecidePage(TestCase):
@@ -98,6 +98,6 @@ class TestGenericXRDS(TestCase):
         requested_url = 'http://requested.invalid/'
         (endpoint,) = applyFilter(requested_url, response.content)
 
-        self.failUnlessEqual(YADIS_CONTENT_TYPE, response['Content-Type'])
-        self.failUnlessEqual(type_uris, endpoint.type_uris)
-        self.failUnlessEqual(endpoint_url, endpoint.uri)
+        self.assertEqual(YADIS_CONTENT_TYPE, response['Content-Type'])
+        self.assertEqual(type_uris, endpoint.type_uris)
+        self.assertEqual(endpoint_url, endpoint.uri)

--- a/openid/test/__init__.py
+++ b/openid/test/__init__.py
@@ -154,8 +154,8 @@ def djangoExampleTests():
     try:
         import django.test.simple
     except ImportError:
-        warnings.warn("django.test.simple not found; skipping django examples.")
-        return 0
+        raise unittest.SkipTest("Skipping django examples. "
+                                "django.test.simple not found.")
 
     import djopenid.server.models
     import djopenid.consumer.models

--- a/openid/test/storetest.py
+++ b/openid/test/storetest.py
@@ -3,7 +3,6 @@ import string
 import time
 import os
 import uuid
-import warnings
 
 from openid.association import Association
 from openid.cryptutil import randomString
@@ -253,8 +252,9 @@ def test_mysql():
     try:
         import MySQLdb
     except ImportError:
-        warnings.warn("Could not import MySQLdb. Skipping MySQL store tests.")
-        pass
+        raise unittest.SkipTest('Skipping MySQL store tests. '
+                                'Could not import MySQLdb.')
+
     else:
         db_user = os.environ.get('TEST_MYSQL_USER', 'openid_test')
         db_passwd = ''
@@ -268,9 +268,9 @@ def test_mysql():
                                    host=db_host)
         except MySQLdb.OperationalError as why:
             if why.args[0] == 2005:
-                print(('Skipping MySQL store test (cannot connect '
-                       'to test server on host %r)' % (db_host,)))
-                return
+                raise unittest.SkipTest('Skipping MySQL store test. '
+                                        'Cannot connect to server on host %r.'
+                                        % (db_host,))
             else:
                 raise
 
@@ -321,8 +321,8 @@ def test_postgresql():
     try:
         import psycopg2
     except ImportError:
-        warnings.warn("Could not import psycopg2. Skipping PostgreSQL store tests.")
-        pass
+        raise unittest.SkipTest('Skipping PostgreSQL store tests. '
+                                'Could not import psycopg2.')
     else:
         db_name = getTmpDbName()
         db_user = os.environ.get('TEST_POSTGRES_USER', 'openid_test')
@@ -333,8 +333,8 @@ def test_postgresql():
             conn_create = psycopg2.connect(database='template1', user=db_user,
                                            host=db_host)
         except psycopg2.OperationalError as why:
-            warnings.warn("Skipping PostgreSQL store test: %s" % why)
-            return
+            raise unittest.SkipTest('Skipping PostgreSQL store test: %s'
+                                     % why)
 
         conn_create.autocommit = True
 

--- a/openid/test/test_fetchers.py
+++ b/openid/test/test_fetchers.py
@@ -107,10 +107,9 @@ def run_fetcher_tests(server):
                 try:
                     __import__(library_name)
                 except ImportError:
-                    warnings.warn(
+                    raise unittest.SkipTest(
                         'Skipping tests for %r fetcher because '
                         'the library did not import.' % (library_name,))
-                    pass
                 else:
                     assert False, ('%s present but not detected' % (
                         library_name,))


### PR DESCRIPTION
- Raise unittest.SkipTest(msg) rather than warning.warn(msg)
- Fix usage of deprecated TestCase methods