### PR TITLE
#14 Import error due release 3.5 of Python

### DIFF
--- a/openid/test/test_parsehtml.py
+++ b/openid/test/test_parsehtml.py
@@ -1,4 +1,3 @@
-from html.parser import HTMLParseError
 import os.path
 import unittest
 import sys
@@ -33,8 +32,6 @@ class _TestCase(unittest.TestCase):
 
             msg = "%r != %r for case %s" % (found, self.expected, self.case)
             self.assertEqual(found, self.expected, msg)
-        except HTMLParseError:
-            self.assertTrue(self.expected == 'None', (self.case, self.expected))
         else:
             self.assertTrue(self.expected == 'EOF', (self.case, self.expected))
 

--- a/openid/yadis/parsehtml.py
+++ b/openid/yadis/parsehtml.py
@@ -1,6 +1,6 @@
 __all__ = ['findHTMLMeta', 'MetaNotFound']
 
-from html.parser import HTMLParser, HTMLParseError
+from html.parser import HTMLParser
 import html.entities
 import re
 
@@ -187,10 +187,6 @@ def findHTMLMeta(stream):
         chunks.append(chunk)
         try:
             parser.feed(chunk)
-        except HTMLParseError as why:
-            # HTML parse error, so bail
-            chunks.append(stream.read())
-            break
         except ParseDone as why:
             uri = why.args[0]
             if uri is None:


### PR DESCRIPTION
HTMLParserError is no longer thrown by HTMLParser and thus was removed. The dependency and except blocks were removed.