### PR TITLE
Handle skiptest in admin/runtests.

### DIFF
--- a/admin/runtests
+++ b/admin/runtests
@@ -195,7 +195,12 @@ def main():
     fixpath()
     other_failed = otherTests()
     pyunit_result = pyunitTests()
-    django_failures = django_tests()
+
+    try:
+        django_failures = 0
+        django_failures = django_tests()
+    except unittest.SkipTest as e:
+        print(e)
 
     if other_failed:
         print ('Failures:', ', '.join(other_failed))


### PR DESCRIPTION
These never got handled in 42bf0e05da6c9a326287ef2404b545c97c8a9e41.