### PR TITLE
Fix pycurl with proxy

### DIFF
--- a/openid/fetchers.py
+++ b/openid/fetchers.py
@@ -322,7 +322,7 @@ class CurlHTTPFetcher(HTTPFetcher):
         header_file.seek(0)
 
         # Remove all non "name: value" header lines from the input
-        lines = [line.decode().strip() for line in header_file if ':' in line]
+        lines = [line.decode().strip() for line in header_file if b':' in line]
 
         headers = {}
         for line in lines:

--- a/openid/fetchers.py
+++ b/openid/fetchers.py
@@ -321,18 +321,8 @@ class CurlHTTPFetcher(HTTPFetcher):
     def _parseHeaders(self, header_file):
         header_file.seek(0)
 
-        # Remove the status line from the beginning of the input
-        unused_http_status_line = header_file.readline().lower()
-        if unused_http_status_line.startswith(b'http/1.1 100 '):
-            unused_http_status_line = header_file.readline()
-            unused_http_status_line = header_file.readline()
-
-        lines = [line.decode().strip() for line in header_file]
-
-        # and the blank line from the end
-        empty_line = lines.pop()
-        if empty_line:
-            raise HTTPError("No blank line at end of headers: %r" % (line,))
+        # Remove all non "name: value" header lines from the input
+        lines = [line.decode().strip() for line in header_file if ':' in line]
 
         headers = {}
         for line in lines:


### PR DESCRIPTION
So I ran into an error while using this (with the optional pycurl dependency) behind a squid proxy where the headers are of the format:

```
HTTP/1.0 200 Connection established

HTTP/1.1 200 OK
...
```

This fixes that for me. Was also part of an original PR to the ancient predecessor (https://github.com/openid/python-openid/pull/79/files and https://github.com/openid/python-openid/pull/76/files is similar).

Passes tests ran with $ tox -e py35
If you want a test specifically for this or anything else, just let me know.
Thanks.