### PR TITLE
Fix some Deprecation and Resource warnings.

### DIFF
--- a/admin/build_discover_data.py
+++ b/admin/build_discover_data.py
@@ -53,8 +53,8 @@ def buildDiscover(base_url, out_dir):
                                          discoverdata.example_xrds)
 
         out_file_name = os.path.join(out_dir, test_name)
-        out_file = open(out_file_name, 'w', encoding="utf-8")
-        out_file.write(data)
+        with open(out_file_name, 'w', encoding="utf-8") as out_file:
+            out_file.write(data)
 
     manifest = [manifest_header]
     for success, input_name, id_name, result_name in discoverdata.testlist:

--- a/openid/extensions/draft/pape5.py
+++ b/openid/extensions/draft/pape5.py
@@ -32,7 +32,7 @@ AUTH_PHISHING_RESISTANT = \
 AUTH_NONE = \
     'http://schemas.openid.net/pape/policies/2007/06/none'
 
-TIME_VALIDATOR = re.compile('^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
+TIME_VALIDATOR = re.compile(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
 
 LEVELS_NIST = 'http://csrc.nist.gov/publications/nistpubs/800-63/SP800-63V1_0_2.pdf'
 LEVELS_JISA = 'http://www.jisa.or.jp/spec/auth_level.html'

--- a/openid/test/test_accept.py
+++ b/openid/test/test_accept.py
@@ -9,11 +9,8 @@ def getTestData():
     () -> [(int, str)]
     """
     filename = os.path.join(os.path.dirname(__file__), 'data', 'accept.txt')
-    i = 1
-    lines = []
-    for line in open(filename):
-        lines.append((i, line))
-        i += 1
+    with open(filename, 'rt') as data_file:
+        lines = list(enumerate(data_file, 1))
     return lines
 
 

--- a/openid/test/test_parsehtml.py
+++ b/openid/test/test_parsehtml.py
@@ -74,7 +74,8 @@ def getCases(test_files=default_test_files):
     cases = []
     for filename in test_files:
         test_num = 0
-        data = open(filename).read()
+        with open(filename) as data_file:
+            data = data_file.read()
         for expected, case in parseCases(data):
             test_num += 1
             cases.append((filename, test_num, expected, case))

--- a/openid/urinorm.py
+++ b/openid/urinorm.py
@@ -13,7 +13,7 @@ uri_re = re.compile(uri_pattern)
 #
 # unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
 
-uri_illegal_char_re = re.compile("[^-A-Za-z0-9:/?#[\]@!$&'()*+,;=._~%]",
+uri_illegal_char_re = re.compile(r"[^-A-Za-z0-9:/?#[\]@!$&'()*+,;=._~%]",
                                  re.UNICODE)
 
 authority_pattern = r'^([^@]*@)?([^:]*)(:.*)?'

--- a/openid/yadis/filters.py
+++ b/openid/yadis/filters.py
@@ -12,7 +12,10 @@ __all__ = [
 ]
 
 from openid.yadis.etxrd import expandService
-import collections
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 
 
 class BasicServiceEndpoint(object):
@@ -192,7 +195,7 @@ def mkCompoundFilter(parts):
                 # conversion attribute into the list of endpoint
                 # transformers
                 transformers.append(subfilter.fromBasicServiceEndpoint)
-            elif isinstance(subfilter, collections.Callable):
+            elif isinstance(subfilter, Callable):
                 # It's a simple callable, so add it to the list of
                 # endpoint transformers
                 transformers.append(subfilter)

--- a/openid/yadis/xri.py
+++ b/openid/yadis/xri.py
@@ -31,7 +31,7 @@ def toIRINormal(xri):
     return escapeForIRI(xri)
 
 
-_xref_re = re.compile('\((.*?)\)')
+_xref_re = re.compile(r'\((.*?)\)')
 
 
 def _escape_xref(xref_match):


### PR DESCRIPTION
I realized that there are some deprecation and resource warnings coming from Python. This is my attempt to fix them.

1. Regular expressions should be raw strings in order escape character `\` to have correct meaning there. It's escape character in python strings itself and in regular expressions. If we need it in regular expression which is defined in normal string we actually need double escaping which will make the regex harder to read and understand. Currently if Python see incorrect escape sequence it will ignore it but this behavior is deprecated.
2. `Callable` should be used from `collection.abc` instead of `collection` for Python 3.8 compatibility.
3. Opened resources (files) should be closed after processing is done in order not to leak file descriptors. 