### PR TITLE
Fix issue 46: Move PostgreSQL package's import to class PostgreSQLStore

### DIFF
--- a/openid/store/sqlstore.py
+++ b/openid/store/sqlstore.py
@@ -10,12 +10,6 @@ python -c 'from openid.store import sqlstore; import pysqlite2.dbapi2;'
 import re
 import time
 
-try:
-    import psycopg2
-except ImportError:
-    from psycopg2cffi import compat
-    compat.register()
-
 from openid.association import Association
 from openid.store.interface import OpenIDStore
 from openid.store import nonce
@@ -433,6 +427,13 @@ class PostgreSQLStore(SQLStore):
 
     All other methods are implementation details.
     """
+
+    try:
+        import psycopg2
+    except ImportError:
+        from psycopg2cffi import compat
+        compat.register()
+
     exceptions = None
 
     create_nonce_sql = """


### PR DESCRIPTION
When I use this package, I only need MySQL, and don't need PostgreSQL, but this library force me to install PostgreSQL's package `psycopg2` or `psycopg2cffi`.

That's why I meet issue https://github.com/necaris/python3-openid/issues/46