### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/openid/test/test_fetchers.py
+++ b/openid/test/test_fetchers.py
@@ -222,7 +222,7 @@ def test():
 
     import threading
     server_thread = threading.Thread(target=server.serve_forever)
-    server_thread.setDaemon(True)
+    server_thread.daemon = True
     server_thread.start()
 
     run_fetcher_tests(server)


### PR DESCRIPTION
Fixes #57 