### PR TITLE
Use non-deprecated defusedxml ElementTree first

### DIFF
--- a/openid/oidutil.py
+++ b/openid/oidutil.py
@@ -16,8 +16,8 @@ from urllib.parse import urlencode
 logger = logging.getLogger(__name__)
 
 xxe_safe_elementtree_modules = [
-    'defusedxml.cElementTree',
     'defusedxml.ElementTree',
+    'defusedxml.cElementTree',
 ]
 
 elementtree_modules = [


### PR DESCRIPTION
When importing defusedxml's ElementTree use the non-deprecated import path first to avoid warnings.