### PR TITLE
Decode 'uniq' part of 'assoc_handle' from byte to string

### DIFF
--- a/openid/server/server.py
+++ b/openid/server/server.py
@@ -1243,7 +1243,7 @@ class Signatory(object):
         @returntype: L{openid.association.Association}
         """
         secret = cryptutil.getBytes(getSecretSize(assoc_type))
-        uniq = oidutil.toBase64(cryptutil.getBytes(4))
+        uniq = oidutil.toBase64(cryptutil.getBytes(4)).decode()
         handle = '{%s}{%x}{%s}' % (assoc_type, int(time.time()), uniq)
 
         assoc = Association.fromExpiresIn(self.SECRET_LIFETIME, handle, secret,


### PR DESCRIPTION
The 'uniq' part of 'assoc_handle' is currently inserted as a byte-string eg. {HMAC-SHA256}{6528ff2d}{b'uuLBig=='}.
URL validators filtering on ' therefore rejects openid requests with 'assoc_handle' set.