### PR TITLE
Fix `SyntaxWarning` on Python 3.12

### DIFF
--- a/openid/extensions/draft/pape2.py
+++ b/openid/extensions/draft/pape2.py
@@ -27,7 +27,7 @@ AUTH_MULTI_FACTOR = \
 AUTH_PHISHING_RESISTANT = \
     'http://schemas.openid.net/pape/policies/2007/06/phishing-resistant'
 
-TIME_VALIDATOR = re.compile('^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
+TIME_VALIDATOR = re.compile(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
 
 
 class Request(Extension):


### PR DESCRIPTION
On Python 3.12 the following warning is printed during installation:

```
/usr/local/lib/python3.12/site-packages/openid/extensions/draft/pape2.py:30: SyntaxWarning: invalid escape sequence '\d'
  TIME_VALIDATOR = re.compile('^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
```

This PR resolves this.